### PR TITLE
Support for T2T: generate Refseq and transcriptome data.

### DIFF
--- a/RefFiles/getGenomeSequenceFromBSGenomeT2T.r
+++ b/RefFiles/getGenomeSequenceFromBSGenomeT2T.r
@@ -1,0 +1,78 @@
+library("BSgenome")
+library("BSgenome.Hsapiens.UCSC.hs1")
+
+genome <- getBSgenome("BSgenome.Hsapiens.UCSC.hs1")
+
+chr1 = as.character(genome$chr1)
+chr2 = as.character(genome$chr2)
+chr3 = as.character(genome$chr3)
+chr4 = as.character(genome$chr4)
+chr5 = as.character(genome$chr5)
+chr6 = as.character(genome$chr6)
+chr7 = as.character(genome$chr7)
+chr8 = as.character(genome$chr8)
+chr9 = as.character(genome$chr9)
+chr10 = as.character(genome$chr10)
+chr11 = as.character(genome$chr11)
+chr12 = as.character(genome$chr12)
+chr13 = as.character(genome$chr13)
+chr14 = as.character(genome$chr14)
+chr15 = as.character(genome$chr15)
+chr16 = as.character(genome$chr16)
+chr17 = as.character(genome$chr17)
+chr18 = as.character(genome$chr18)
+chr19 = as.character(genome$chr19)
+chr20 = as.character(genome$chr20)
+chr21 = as.character(genome$chr21)
+chr22 = as.character(genome$chr22)
+chrX = as.character(genome$chrX)
+chrY = as.character(genome$chrY)
+
+## get transcriptome
+load("dataRefSeqT2T.RData")
+cat("loaded refseq")
+
+seqStart = NULL
+seqEnd = NULL
+chr = NULL
+Gene = NULL
+strand = NULL
+
+for(gene in unique(dataRefSeq$V13)){
+	seqStart = c(seqStart,min(dataRefSeq$V2[dataRefSeq$V13==gene])-150)
+	seqEnd = c(seqEnd,max(dataRefSeq$V3[dataRefSeq$V13==gene])+150)
+	chr = c(chr,unique(as.character(dataRefSeq$V1[dataRefSeq$V13==gene])))
+	Gene = c(Gene,gene)
+	strand = c(strand,unique(as.character(dataRefSeq$V6[dataRefSeq$V13==gene])))
+}
+
+transcriptome = data.frame(chr,seqStart,seqEnd,strand,Gene)
+transcriptome = transcriptome[transcriptome$chr!="chrM",]
+
+inverseDic <- data.frame(V1 = c('T','G','C','A','N'),row.names = c('A','C','G','T','N'))
+inverseDic$V1 <- as.character(inverseDic$V1)
+
+getRevSeq <- function(sequence){
+    splitRevSeq = rev(unlist(strsplit(sequence,'|')))
+    seqRev = paste(unlist(lapply(list(splitRevSeq),function(x) inverseDic[x,1])),sep="",collapse="")
+    return(seqRev)
+}
+
+getSeq <- function(chr,start,end){
+	eval(parse(text = paste("sequence = substr(",chr,",",start,",",end,")",sep="")))
+	return(sequence)
+}
+tmpSeq = unlist(mapply(getSeq,transcriptome$chr,transcriptome$seqStart,transcriptome$seqEnd))
+
+transcriptome$seq = tmpSeq
+
+revSeq = unlist(lapply(transcriptome$seq,getRevSeq))
+
+transcriptome$seq[transcriptome$strand=="-"] = revSeq[transcriptome$strand=="-"]
+
+transcriptome_idx = transcriptome[,c(1:4)]
+transcriptome_seq = transcriptome[,c(5:6)]
+cat("finished filling transcriptome")
+
+save(transcriptome_idx, transcriptome_seq,file = "transcriptome_T2T.RData")
+cat("saved transcriptome")

--- a/RefFiles/getRefSeqDatabaseT2T.r
+++ b/RefFiles/getRefSeqDatabaseT2T.r
@@ -1,0 +1,78 @@
+########
+#get RefSeq dataBase from UCSC
+########
+options(stringsAsFactors=FALSE)
+message("Use the URL: http://hgdownload.cse.ucsc.edu/goldenPath/")
+argsFull <- commandArgs()
+Rscript <- argsFull[1]
+
+inputref=dirname(normalizePath(sub("--file=","",argsFull[substr(argsFull,1,7)=="--file="])))
+
+#old format vs new format
+# |  1 | bin          |  1 | chrom        |
+# |  2 | name         |  2 | chromStart   |
+# |  3 | chrom        |  3 | chromEnd     |
+# |  4 | strand       |  4 | name         |
+# |  5 | txStart      |  5 | score        |
+# |  6 | txEnd        |  6 | strand       |
+# |  7 | cdsStart     |  7 | thickStart   |
+# |  8 | cdsEnd       |  8 | thickEnd     |
+# |  9 | exonCount    |  9 | reserved     |
+# | 10 | exonStarts   | 10 | blockCount   |
+# | 11 | exonEnds     | 11 | blockSizes   |
+# | 12 | score        | 12 | chromStarts  |
+# | 13 | name2        | 13 | name2        |
+# | 14 | cdsStartStat | 14 | cdsStartStat |
+# | 15 | cdsEndStat   | 15 | cdsEndStat   |
+# | 16 | exonFrames   | 16 | exonFrames   |
+# |    |              | 17 | type         |
+# |    |              | 18 | geneName     |
+# |    |              | 19 | geneName2    |
+# |    |              | 20 | geneType     |
+
+#open connection
+## message("open connexion...")
+## system("curl -O https://hgdownload.soe.ucsc.edu/gbdb/hs1/ncbiRefSeq/ncbiRefSeqCurated.bb")
+## Requires http://hgdownload.soe.ucsc.edu/admin/exe/biobig
+## Don't write header as it misses a tab somewhere and break the file reading
+system("./bigBedToBed ncbiRefSeqCurated.bb ncbiRefSeqCurated.bed")
+
+message("read files...")
+dat <- read.csv("ncbiRefSeqCurated.bed", sep="\t", header=FALSE)
+dat$V7 = as.numeric(dat$V7)
+
+# No need to rename chromosome in T2T
+
+#remove duplicate transcrit between chrX and chrY
+dat = dat[order(dat$V1),]
+dat = dat[!duplicated(dat$V4),]
+
+#remove transcrit version
+splitTrans = unlist(strsplit(dat$V4,".",fixed=TRUE))
+dat$V4 = splitTrans[seq(from=1,to=length(splitTrans),by=2)]
+
+# Exon relative position and length is already stored
+## dathg19$V17 = unlist(tmpResulthg19[1,])
+## dathg19$V18 = unlist(tmpResulthg19[2,])
+
+#save data
+## message("Save data...")
+
+dataRefSeq = dat[,c(
+  "V1", # chrom
+  "V2", # txStart
+  "V3", # txEnd
+  "V4", # name
+  "V5", # score
+  "V6", # strand
+  "V7", # cdsstart ?
+  "V8", # cdsend ?
+  "V5", # score again
+  "V10", # exoncount
+  "V11", # exon length
+  "V12", # exon relative pos
+  "V13" # name3
+  )]
+## names(dataRefSeq) = paste("V",c(1:13),sep="")
+
+save(dataRefSeq,file = paste(inputref,"dataRefSeqT2T.RData",sep=""))


### PR DESCRIPTION
T2T support by updating refseq and transcriptome data generation. Some minor changes into the main script file to accomodate this new genome (command-line options).

T2T does not provide exactly the same RefSeq curated bed file. We download a BigBed file, convert it to bed and store it as RData using some columns permutations. Transcriptome data is generated likewise.

Note:
- This requires the bigBedToBed executable (downloaded by the script). The script uses chmod +x, which is a security issue
- Tested on 5 pathogenic variant (score 98%) and one with a score of 38% using a manually lifted version.